### PR TITLE
use a different action

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,2 +1,0 @@
-# Set addAssignees to 'author' to set the PR creator as the assignee. https://github.com/kentaro-m/auto-assign-action
-addAssignees: author

--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -1,0 +1,17 @@
+name: 🧼 PR
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-assign:
+    name: Auto-assign author
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: toshimaru/auto-author-assign@7e15cd70c245ad136377c3fab3479815df10d844

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -15,16 +15,6 @@ on:
 permissions: {}
 
 jobs:
-  auto-assign:
-    name: Auto-assign author of a PR
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.event.action == 'opened'
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: toshimaru/auto-author-assign@7e15cd70c245ad136377c3fab3479815df10d844
-
   validate-description:
     name: Validate Description
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -15,6 +15,16 @@ on:
 permissions: {}
 
 jobs:
+  auto-assign:
+    name: Auto-assign author of a PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event.action == 'opened'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: toshimaru/auto-author-assign@7e15cd70c245ad136377c3fab3479815df10d844
+
   validate-description:
     name: Validate Description
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use `toshimaru/auto-author-assign` (with a commit hash) instead of `kentaro-m/auto-assign-action`.
This removes the two-line configuration file and contains the workflow directly in the file.